### PR TITLE
parsing fix for attachments/posts/pages

### DIFF
--- a/index.js
+++ b/index.js
@@ -300,10 +300,12 @@ wp2js.parse = function(opts, callback){
             ret[v] = result[i];
         });
 
-        ret.posts = ret.pages = ret.attachments = [];
+        ret.posts = [];
+        ret.pages = [];
+        ret.attachments = [];
 
         // Filter the different post type
-        result[8].forEach(function(v){
+        result[10].forEach(function(v){
             switch(v.type) {
                 case 'post':
                     ret.posts.push(v);


### PR DESCRIPTION
resolved issue where pages/posts/attachments were not parsed because the array index of 'result' did not match the index of the async call array above; also split out definition of the pages, posts, and attachments arrays to ensure unique contents